### PR TITLE
Obstruct: if schema has an object but source doesn't, default to {}

### DIFF
--- a/obstruct.js
+++ b/obstruct.js
@@ -53,7 +53,7 @@ function createParser (object) {
     }
 
     if (isObject(value)) {
-      result = Obstruct(value, dotProp.get(object, srcKey))
+      result = Obstruct(value, dotProp.get(object, srcKey) || {})
     }
 
     return [key, result]

--- a/test.js
+++ b/test.js
@@ -124,3 +124,25 @@ test('obstruction', function (t) {
 
   t.end()
 })
+
+test('obstruction: schema object but no data object', function (t) {
+  const obstruct = Obstruct({
+    deeply: {
+      nested: true
+    }
+  })
+
+  t.deepEqual(
+    obstruct({}),
+    {deeply: {nested: undefined}},
+    'works when data has no object'
+  )
+
+  t.deepEqual(
+    obstruct({deeply: {nested: 'foo'}}),
+    {deeply: {nested: 'foo'}},
+    'works when data has object'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Before, this would throw a null pointer exception.

Why? I want to use Obstruct to give me back data matching the structure I defined in my schema, no matter what -- even if the object I pass in is empty.
